### PR TITLE
Increase version (3.2.3). Move back IUO SwiftTypeGetter conforming.

### DIFF
--- a/DITranquillity.podspec
+++ b/DITranquillity.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = 'DITranquillity'
-  s.version      = '3.2.2'
+  s.version      = '3.2.3'
   s.summary      = 'DITranquillity - Dependency injection for iOS/macOS/tvOS (Swift) '
 
   s.description  = <<-DESC

--- a/Sources/Core/Private/Helpers.swift
+++ b/Sources/Core/Private/Helpers.swift
@@ -29,12 +29,9 @@ protocol TypeGetter {
 
 protocol SwiftTypeGetter: TypeGetter {}
 
-#if swift(>=4.1)
-#else
 extension ImplicitlyUnwrappedOptional: SwiftTypeGetter {
   static var type: DIAType { return Wrapped.self }
 }
-#endif
 
 extension Optional: SwiftTypeGetter {
   static var type: DIAType { return Wrapped.self }


### PR DESCRIPTION
(Unfortunately, back warning)