### PR TITLE
Fix "swift build" compilation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# v3.7.3
+* Fix "swift build" command compillation error
+
 # v3.7.1
 * Fully support optional register. `c.register { optionalValue }` now can correct resolve.
 * Improve logs for optional register if optional is nil.

--- a/Sources/DITranquillity/Private/GlobalState.swift
+++ b/Sources/DITranquillity/Private/GlobalState.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2019 Alexander Ivlev. All rights reserved.
 //
 
+import Foundation
 
 class GlobalState {
   private static let lastComponentKey = "GlobalState_Last_Component\(UUID().uuidString)"


### PR DESCRIPTION
No need to release cocoa pods version. Issue only in swift package building