### PR TITLE
Handle argument injection with name and tag

### DIFF
--- a/Sources/Core/Internal/AnyArguments.swift
+++ b/Sources/Core/Internal/AnyArguments.swift
@@ -48,11 +48,13 @@ public struct AnyArguments {
   }
 
   internal func getArguments(for component: Component) -> Arguments? {
-    let types = Set(([component.info.type] + component.alternativeTypes.compactMap {
-      if case .type(let type) = $0 {
+    let types = Set(([component.info.type] + component.alternativeTypes.map {
+      switch $0 {
+      case let .type(type),
+           let .name(_, type),
+           let .tag(_, type):
         return type
       }
-      return nil
     }).map { ObjectIdentifier($0) })
 
     let relevantTypesWithArgs = typesWithArgs.filter { types.contains($0.type) }


### PR DESCRIPTION
Improved argument injection for custom typing. Currently not work with case:
```swift
container.register { MyClass(inj: arg($0) }
    .as(name: "Name", MyProtocol.self)
    .as(tag: MyTag.self, MyProtocol.self)
let arg = AnyArgument(type: MyProtocol.self, value: 1)
let obj: MyProtocol = container.resolve(arg)
```
PR will fix this and allow usage of arguments with taged and named registrations
